### PR TITLE
Partial / conditional indices

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -118,6 +118,12 @@ indexes for a given model--<code>ActiveRecord::Base</code>--class. For example:
 
 Would return all the indexes for the +invoices+ table.
 
+=== Partial Indexes (indexes with conditions)
+
+Partial indexes index only a portion of the database. Only PostgreSQL supports this feature.
+
+  add_index :users, :username, :unique => true, :conditions => {:state => "active"}
+
 === Schema Defining
 
 The plugin also adds a method--<code>defining?()</code>--to

--- a/lib/red_hill_consulting/core/active_record/connection_adapters/index_definition.rb
+++ b/lib/red_hill_consulting/core/active_record/connection_adapters/index_definition.rb
@@ -7,5 +7,13 @@ module RedHillConsulting::Core::ActiveRecord::ConnectionAdapters
 		def case_sensitive=(case_sensitive)
 			@case_sensitive = case_sensitive
 		end
+
+		def conditions=(conditions)
+			@conditions = conditions
+		end
+
+		def conditions
+			@conditions
+		end
 	end
 end

--- a/lib/red_hill_consulting/core/active_record/schema_dumper.rb
+++ b/lib/red_hill_consulting/core/active_record/schema_dumper.rb
@@ -28,6 +28,7 @@ module RedHillConsulting::Core::ActiveRecord
         stream.print "  add_index #{index.table.inspect}, #{index.columns.inspect}, :name => #{index.name.inspect}"
         stream.print ", :unique => true" if index.unique
         stream.print ", :case_sensitive => false" unless index.case_sensitive?
+        stream.print ", :conditions => #{index.conditions.inspect}" unless index.conditions.blank?
         stream.puts
       end
       stream.puts unless indexes.empty?

--- a/lib/redhillonrails_core.rb
+++ b/lib/redhillonrails_core.rb
@@ -35,5 +35,3 @@ ActiveRecord::ConnectionAdapters::TableDefinition.send(:include, RedHillConsulti
 ActiveRecord::ConnectionAdapters::Column.send(:include, RedHillConsulting::Core::ActiveRecord::ConnectionAdapters::Column)
 ActiveRecord::ConnectionAdapters::AbstractAdapter.send(:include, RedHillConsulting::Core::ActiveRecord::ConnectionAdapters::AbstractAdapter)
 ActiveRecord::ConnectionAdapters::SchemaStatements.send(:include, RedHillConsulting::Core::ActiveRecord::ConnectionAdapters::SchemaStatements)
-
-

--- a/redhillonrails_core.gemspec
+++ b/redhillonrails_core.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{redhillonrails_core}
-  s.version = "1.0.6"
+  s.version = "1.0.6.adgear"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Micha\305\202 \305\201omnicki"]


### PR DESCRIPTION
We needed to generate indices where only a subset of the table needed to be included in the unique constraint. That's where PostgreSQL shines: it has built-in support for conditions on the CREATE INDEX SQL statement.

This commit supports round-tripping through the schema dumper. The only caveat is that in the migration, one could specify the condition as a Hash or Array, but in the dumped schema, the SQL condition will be the exact text the database server returns.

I tried making other adapters raise an ArgumentError, but that didn't work out at all: my code wasn't being run at all.

I hope this meets your approval!
François
