### PR TITLE
Schema ordering

### DIFF
--- a/lib/redhillonrails_core/active_record/schema_dumper.rb
+++ b/lib/redhillonrails_core/active_record/schema_dumper.rb
@@ -25,6 +25,10 @@ module RedhillonrailsCore
 
       def indexes_with_redhillonrails_core(table, stream)
         indexes = @connection.indexes(table)
+        
+        indexes.sort! do |a, b|
+          a.columns.sort <=> b.columns.sort
+        end
         indexes.each do |index|
           unless index.columns.blank? 
             stream.print "  add_index #{index.table.inspect}, #{index.columns.inspect}, :name => #{index.name.inspect}"
@@ -48,6 +52,10 @@ module RedhillonrailsCore
 
       def foreign_keys(table, stream)
         foreign_keys = @connection.foreign_keys(table)
+
+        foreign_keys.sort! do |a, b|
+          a.column_names.sort <=> b.column_names.sort
+        end
         foreign_keys.each do |foreign_key|
           stream.print "  "
           stream.print foreign_key.to_dump


### PR DESCRIPTION
Hi,

This is a patch to order indexes and foreign keys when dumping the schema.

Since I work with many databases and they have been migrated/reversed on different times my version control tool reports many spurious diffs on db/schema.rb about the order the keys/indexes where created. This fixes the issue.

Thanks.
