### PR TITLE
Table name quoted in add/remove foreign key queries

### DIFF
--- a/lib/redhillonrails_core/active_record/connection_adapters/abstract_adapter.rb
+++ b/lib/redhillonrails_core/active_record/connection_adapters/abstract_adapter.rb
@@ -53,11 +53,11 @@ module RedhillonrailsCore
 
         def add_foreign_key(table_name, column_names, references_table_name, references_column_names, options = {})
           foreign_key = ForeignKeyDefinition.new(options[:name], table_name, column_names, ::ActiveRecord::Migrator.proper_table_name(references_table_name), references_column_names, options[:on_update], options[:on_delete], options[:deferrable])
-          execute "ALTER TABLE #{table_name} ADD #{foreign_key}"
+          execute "ALTER TABLE `#{table_name}` ADD #{foreign_key}"
         end
 
         def remove_foreign_key(table_name, foreign_key_name, options = {})
-          execute "ALTER TABLE #{table_name} DROP CONSTRAINT #{foreign_key_name}"
+          execute "ALTER TABLE `#{table_name}` DROP CONSTRAINT #{foreign_key_name}"
         end
 
         def drop_table_with_redhillonrails_core(name, options = {})


### PR DESCRIPTION
So we can have, for example, a table named "references". Otherwise you've got a SQL syntax error.
